### PR TITLE
Add plugin to render notebooks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ extra_css:
 nav:
   - Introduction: 'README.md'
 #  - API: 'api/reference.md'
+  - notebook: 'example.ipynb'
   - 'changelog.md'
   - 'contributing.md'
   - 'conduct.md'
@@ -35,4 +36,11 @@ plugins:
 - search
 - mkdocstrings
 - privacy
+- mkdocs-jupyter:
+    # TODO: when we can configure aiod, we should start running notebooks
+    # execute: true
+    # allow_errors: false
+    execute_ignore:
+      - "*.py"
+    include_source: True
 


### PR DESCRIPTION
We can use the `mkdocs-jupyter` plugin to render the notebook and include it as a subpage in the documentation.
Seems to work out of the box, though of course with the current API trying to connect to a local server first we can not actually run the notebook when building docs (generally speaking we probably don't want to assume a local server is present as that will impose serious overhead in the workflow).