### PR TITLE
Limit upper bound griffe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ doc = [
     "mkdocs-material",
     "mkdocstrings-python",
     "mkdocs-jupyter",
+    "griffe<1.0",
 ]
 
 [tool.commitizen]


### PR DESCRIPTION
Griffe 1.0 changes how extensions work, so our extension needs to be updated before we can use it.