### PR TITLE
Update for Version 2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
           cache: pip
       - run: python -m pip install ".[dev]"
       - run: python -m pytest tests
+      - run: python -m pytest -m server tests
   bump:
     needs: [test-code]
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests.yml
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+        name: Install Dependencies
+      - run: python -m pytest tests
+        name: Run local tests
+      - run: python -m pytest -m server tests
+        name: Run integration tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,9 @@ version_files = ["pyproject.toml:version", "src/aiod/__version__.py"]
 
 [project.entry-points."mkdocs.plugins"]
 asset-type-replacer = "docs.tools.asset_type_replacer:AssetTypeReplacer"
+
+[tool.pytest.ini_options]
+markers = [
+    "server: connects to an AIoD server",
+]
+addopts = "-m 'not server'"

--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -63,7 +63,9 @@ def counts(
         per_platform: Whether to list counts per platform (default is False).
 
     Returns:
-        The number ASSET_TYPE assets in the metadata catalogue. If the parameter per_platform is True, it returns a dictionary with platform names as keys and the number of ASSET_TYPE assets from that platform as values.
+        The number ASSET_TYPE assets in the metadata catalogue.
+        If the parameter per_platform is True, it returns a dictionary with platform names
+        as keys and the number of ASSET_TYPE assets from that platform as values.
     """
 
     url = url_to_resource_counts(version, per_platform, asset_type)
@@ -72,7 +74,7 @@ def counts(
 
 
 def get_asset(
-    identifier: int,
+    identifier: str,
     *,
     asset_type: str,
     version: str | None = None,
@@ -127,7 +129,7 @@ def get_asset_from_platform(
 
 def get_content(
     *,
-    identifier: int,
+    identifier: str,
     asset_type: str,
     distribution_idx: int = 0,
     version: str | None = None,
@@ -199,7 +201,7 @@ def search(
 
 
 async def get_assets_async(
-    identifiers: list[int],
+    identifiers: list[str],
     *,
     asset_type: str,
     version: str | None = None,

--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -6,7 +6,7 @@ from aiod.configuration import config
 
 
 def url_to_get_asset(
-    asset_type: str, identifier: int, version: str | None = None
+    asset_type: str, identifier: str, version: str | None = None
 ) -> str:
     version = version or config.version
     url = f"{config.api_base_url}{version}/{asset_type}/{identifier}"
@@ -59,7 +59,7 @@ def url_to_resource_counts(
 
 def url_to_get_content(
     asset_type: str,
-    identifier: int,
+    identifier: str,
     distribution_idx: int,
     version: str | None = None,
 ) -> str:

--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -79,7 +79,6 @@ def url_to_get_list_from_platform(
 
     query = urllib.parse.urlencode({"offset": offset, "limit": limit})
     version = version or config.version
-
     url = f"{config.api_base_url}{version}/platforms/{platform}/{asset_type}?{query}"
     return url
 

--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -9,7 +9,7 @@ def url_to_get_asset(
     asset_type: str, identifier: int, version: str | None = None
 ) -> str:
     version = version or config.version
-    url = f"{config.api_base_url}{asset_type}/{version}/{identifier}"
+    url = f"{config.api_base_url}{version}/{asset_type}/{identifier}"
     return url
 
 
@@ -19,7 +19,7 @@ def url_to_get_list(
 
     query = urllib.parse.urlencode({"offset": offset, "limit": limit})
     version = version or config.version
-    url = f"{config.api_base_url}{asset_type}/{version}?{query}"
+    url = f"{config.api_base_url}{version}/{asset_type}?{query}"
     return url
 
 
@@ -42,7 +42,7 @@ def url_to_search(
     }
     query = urllib.parse.urlencode(query_params, doseq=True).lower()
     version = version or config.version
-    url = f"{config.api_base_url}search/{asset_type}/{version}?{query}"
+    url = f"{config.api_base_url}{version}/search/{asset_type}?{query}"
     return url
 
 
@@ -53,7 +53,7 @@ def url_to_resource_counts(
 ) -> str:
     query = urllib.parse.urlencode({"detailed": per_platform}).lower()
     version = version or config.version
-    url = f"{config.api_base_url}counts/{asset_type}/{version}?{query}"
+    url = f"{config.api_base_url}{version}/counts/{asset_type}?{query}"
     return url
 
 
@@ -64,7 +64,7 @@ def url_to_get_content(
     version: str | None = None,
 ) -> str:
     version = version or config.version
-    url = f"{config.api_base_url}{asset_type}/{version}/{identifier}/content"
+    url = f"{config.api_base_url}{version}/{asset_type}/{identifier}/content"
     url += f"/{distribution_idx}" if distribution_idx else ""
     return url
 
@@ -80,7 +80,7 @@ def url_to_get_list_from_platform(
     query = urllib.parse.urlencode({"offset": offset, "limit": limit})
     version = version or config.version
 
-    url = f"{config.api_base_url}platforms/{platform}/{asset_type}/{version}?{query}"
+    url = f"{config.api_base_url}{version}/platforms/{platform}/{asset_type}?{query}"
     return url
 
 
@@ -91,5 +91,5 @@ def url_to_get_asset_from_platform(
     version: str | None = None,
 ) -> str:
     version = version or config.version
-    url = f"{config.api_base_url}platforms/{platform}/{asset_type}/{version}/{platform_identifier}"
+    url = f"{config.api_base_url}{version}/platforms/{platform}/{asset_type}/{platform_identifier}"
     return url

--- a/src/aiod/configuration/_config.py
+++ b/src/aiod/configuration/_config.py
@@ -16,7 +16,9 @@ class Config:
     access_token: str | None = None
     refresh_token: str | None = None
 
-    _observers: dict[str, set[AttributeObserver]] = field(default_factory=lambda: defaultdict(set))
+    _observers: dict[str, set[AttributeObserver]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
 
     def subscribe(self, attribute: str, on_change: AttributeObserver):
         if on_change not in self._observers[attribute]:
@@ -33,7 +35,7 @@ class Config:
 
 config = Config(
     api_base_url="https://api.aiod.eu/",
-    version="v1",
+    version="v2",
     auth_server_url="https://auth.aiod.eu/aiod-auth/",
     realm="aiod",
     client_id="aiod-sdk",

--- a/src/aiod/default/counts.py
+++ b/src/aiod/default/counts.py
@@ -24,7 +24,7 @@ def asset_counts(
     version = version or config.version
     url = f"{config.api_base_url}counts"
     if version:
-        url += "/" + version
+        url = f"{config.api_base_url}{version}/counts"
 
     res = requests.get(url)
 

--- a/src/aiod/default/counts.py
+++ b/src/aiod/default/counts.py
@@ -22,9 +22,7 @@ def asset_counts(
         pd.DataFrame | dict: Counts as a Pandas data frame or a dictionary.
     """
     version = version or config.version
-    url = f"{config.api_base_url}counts"
-    if version:
-        url = f"{config.api_base_url}{version}/counts"
+    url = f"{config.api_base_url}{version}/counts"
 
     res = requests.get(url)
 

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -14,7 +14,7 @@ def test_counts():
             res_body = f.read()
         mocked_requests.add(
             responses.GET,
-            url=f"{config.api_base_url}counts/{config.version}",
+            url=f"{config.api_base_url}{config.version}/counts",
             body=res_body,
             status=200,
         )

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -75,7 +75,7 @@ def test_endpoint_get_list(asset_name):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}{asset_name}/{config.version}?offset=0&limit=10",
+            f"{config.api_base_url}{config.version}/{asset_name}?offset=0&limit=10",
             body=b'[{"resource_1": "info"},{"resource_2": "info"}]',
             status=200,
         )
@@ -89,7 +89,7 @@ def test_endpoint_counts(asset_name):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}counts/{asset_name}/{config.version}?detailed=false",
+            f"{config.api_base_url}{config.version}/counts/{asset_name}?detailed=false",
             body=b"2",
             status=200,
         )
@@ -103,7 +103,7 @@ def test_endpoint_get_asset(asset_name):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}{asset_name}/{config.version}/1",
+            f"{config.api_base_url}{config.version}/{asset_name}/1",
             body=b'{"resource":"fake_details"}',
             status=200,
         )
@@ -118,7 +118,7 @@ def test_endpoint_get_list_from_platform(asset_name):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}platforms/{platform_name}/{asset_name}/{config.version}?offset=0&limit=10",
+            f"{config.api_base_url}{config.version}/platforms/{platform_name}/{asset_name}?offset=0&limit=10",
             body=b'[{"resource_1": "info"},{"resource_2": "info"}]',
             status=200,
         )
@@ -134,7 +134,7 @@ def test_endpoint_get_asset_from_platform(asset_name):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}platforms/{platform_name}/{asset_name}/{config.version}/{platform_identifier}",
+            f"{config.api_base_url}{config.version}/platforms/{platform_name}/{asset_name}/{platform_identifier}",
             body=b'{"resource":"fake_details"}',
             status=200,
         )
@@ -154,7 +154,7 @@ def test_get_content(asset_name):
             res_body = f.read()
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}{asset_name}/{config.version}/1/content",
+            f"{config.api_base_url}{config.version}/{asset_name}/1/content",
             body=res_body,
             status=200,
         )
@@ -170,7 +170,7 @@ def test_get_content_with_distribution_idx(asset_name):
             res_body = f.read()
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}{asset_name}/{config.version}/1/content/2",
+            f"{config.api_base_url}{config.version}/{asset_name}/1/content/2",
             body=res_body,
             status=200,
         )
@@ -193,7 +193,7 @@ def test_search(asset_with_search):
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{config.api_base_url}search/{asset_with_search}/{config.version}{query}",
+            f"{config.api_base_url}{config.version}/search/{asset_with_search}{query}",
             body=b'{"total_hits": 2,"resources": [{"resource_1": "info"},{"resource_2": "info"}],"limit": 10,"offset": 0}',
             status=200,
         )
@@ -214,12 +214,12 @@ def test_endpoint_get_asset_async(asset_name):
     loop = asyncio.get_event_loop()
     with aioresponses() as mocked_responses:
         mocked_responses.get(
-            f"{config.api_base_url}{asset_name}/{config.version}/1",
+            f"{config.api_base_url}{config.version}/{asset_name}/1",
             payload={"resource": "fake_details"},
             status=200,
         )
         mocked_responses.get(
-            config.api_base_url + f"{asset_name}/" + config.version + "/" + "3",
+            f"{config.api_base_url}{config.version}/{asset_name}/3",
             payload={"resource": "fake_details_2"},
             status=200,
         )
@@ -238,12 +238,12 @@ def test_endpoint_get_list_async(asset_name):
     loop = asyncio.get_event_loop()
     with aioresponses() as mocked_responses:
         mocked_responses.get(
-            f"{config.api_base_url}{asset_name}/{config.version}?offset=0&limit=2",
+            f"{config.api_base_url}{config.version}/{asset_name}?offset=0&limit=2",
             payload=[{"resource_1": "info"}, {"resource_2": "info"}],
             status=200,
         )
         mocked_responses.get(
-            f"{config.api_base_url}{asset_name}/{config.version}?offset=2&limit=1",
+            f"{config.api_base_url}{config.version}/{asset_name}?offset=2&limit=1",
             payload=[{"resource_3": "info"}],
             status=200,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,16 @@ import aiod
 
 
 @pytest.mark.server()
-def test_get_dataset_from_server():
+def test_get_dataset_from_default_version_server():
+    datasets = aiod.datasets.get_list()
+    assert len(datasets) == 10
+    dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])
+    assert dataset["name"] == datasets["name"].iloc[0]
+
+
+@pytest.mark.server()
+def test_get_dataset_from_latest_version_server():
+    aiod.config.version = ""
     datasets = aiod.datasets.get_list()
     assert len(datasets) == 10
     dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,18 +8,15 @@ import pytest
 
 import aiod
 
-
-@pytest.mark.server()
-def test_get_dataset_from_default_version_server():
-    datasets = aiod.datasets.get_list()
-    assert len(datasets) == 10
-    dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])
-    assert dataset["name"] == datasets["name"].iloc[0]
+DEFAULT_MARKER = "default"
+LATEST_VERSION_MARKER = ""
 
 
 @pytest.mark.server()
-def test_get_dataset_from_latest_version_server():
-    aiod.config.version = ""
+@pytest.mark.parametrize("version", [DEFAULT_MARKER, LATEST_VERSION_MARKER])
+def test_get_dataset_list_from_default_version_server(version: str):
+    if version == LATEST_VERSION_MARKER:
+        aiod.config.version = LATEST_VERSION_MARKER
     datasets = aiod.datasets.get_list()
     assert len(datasets) == 10
     dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,17 @@
+""" Tests which connect to the server.
+
+Do not add new tests unless there is a very good reason.
+These tests do not run with the default test configuration.
+
+"""
+import pytest
+
+import aiod
+
+
+@pytest.mark.server()
+def test_get_dataset_from_server():
+    datasets = aiod.datasets.get_list()
+    assert len(datasets) == 10
+    dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])
+    assert dataset["name"] == datasets["name"].iloc[0]


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Prepare the Python package for working with the new style version URLs.
Still some work left to do on making sure the mocked responses in the tests mimic newer server versions.
Should we make a script which produces files for "golden rule" tests? i.e., the real world output of the production server.
If then store that under a structured directory folder, it would be easy to automate the mocks.
We should also test more endpoints in the integration tests (which run only on CI)


